### PR TITLE
fix: Added missing information on Licence file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2019 Decathlon
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Why? 
The provided licence file was the default one but, at the end of the file, some information about the owner was missing

## What?
Decathlon information are now correctly on the licence file