### PR TITLE
fix: removing broken filters

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -1,14 +1,11 @@
 on: milestone
+  types: [closed]
 name: Milestone Closure
 jobs:
-  action-filter:
-    runs-on: ubuntu-18.04
+  create-release:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: action-filter
-      uses: actions/bin/filter@master
-      with:
-        args: action closed
     - name: Create Release Notes
       uses: ./
       env:

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -1,5 +1,6 @@
-on: milestone
-  types: [closed]
+on: 
+  milestone:
+    types: [closed]
 name: Milestone Closure
 jobs:
   create-release:

--- a/README.md
+++ b/README.md
@@ -78,17 +78,13 @@ Create a file into your root project directory: `.github/workflows/release-notes
 ```yaml
 # Trigger the workflow on milestone events
 on: milestone
+  types: [closed]
 name: Milestone Closure
 jobs:
-  action-filter:
-    runs-on: ubuntu-18.04
+  create-release-notes:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: action-filter
-      uses: actions/bin/filter@master
-      with:
-        # We filter on closing (milestone) action
-        args: action closed
     - name: Create Release Notes
       uses: docker://decathlon/release-notes-generator-action:2.0.0
       env:


### PR DESCRIPTION
# Workflow Filter

## Why?
With the migration to Actions V2, GitHub introduces a new way to filter on *action  types* and it seems in these latest days the old way is discontinued and removed from the available actions.
As described in the official [documentation](https://help.github.com/en/articles/workflow-syntax-for-github-actions#onevent_nametypes), the new way to filter is the following one:
```
# Trigger the workflow on pull request activity
on:
  release
    # Only use the types keyword to narrow down the activity types that will trigger your workflow.
    types: [published, created, edited]
```

## What?
The workflow is just aligned with this new filter style with an updated documentation too.