### PR TITLE
feat: YML file to configure release notes tags

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,0 +1,9 @@
+releasenotes:
+    sections:
+    - title: "Enhancements"
+        emoji: ":star:"
+        labels: ["new"]
+    - title: "Bugs"
+        emoji: ":beetle:"
+        labels: ["fix"]
+  

--- a/README.md
+++ b/README.md
@@ -151,6 +151,21 @@ Creating release notes for Milestone 1 into the Sprint_10.md file
 ### SUCCEEDED Create Release Notes 15:53:53Z (15.913s)
 ```
 
+## Section configuration
+You can manage the sections and how they are used by the release generator, creating the `.github/release-notes.yml` file in the repository where you activate the action.
+An example of file content (you can find detaild information direactly on the [Spring repository](https://github.com/spring-io/github-release-notes-generator))
+```
+releasenotes:
+  sections:
+  - title: "Enhancements"
+    emoji: ":star:"
+    labels: ["new"]
+  - title: "Bugs"
+    emoji: ":beetle:"
+    labels: ["fix"]
+```
+In the sections list you can configure each seaction with an emoji and a list of labels to take care of for this section.
+
 ## How to use the generated file
 The idea is to keep the control about what to do with the release notes file.  
 So simply link a new action and: send it by mail, push it on your website, on the github wiki, ...

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,6 @@
 name: Release notes generator
 author: Decathlon <developers@decathlon.com>
 description: This Github action <strong>automatically creates a release notes</strong> when a milestone is closed.
-Each time a milestone is closed, this GitHub action scans its attached issues and pull requests, then automatically generates a wonderful release note.
-<p align="center">
-<img src="https://github.com/Decathlon/release-notes-generator-action/raw/master/images/release_notes.png" alt="Example illustration"/>
-</p>
 runs:
   using: 'docker'
   image: 'docker://decathlon/release-notes-generator-action:2.0.1'

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,9 @@
+name: Release notes generator
+author: Decathlon <developers@decathlon.com>
+description: This Github action <strong>automatically creates a release notes</strong> when a milestone is closed.
+runs:
+  using: 'docker'
+  image: 'docker://decathlon/release-notes-generator-action:2.1.0'
+branding:
+  icon: tag
+  color: blue

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,0 @@
-name: Release notes generator
-author: Decathlon <developers@decathlon.com>
-description: This Github action <strong>automatically creates a release notes</strong> when a milestone is closed.
-runs:
-  using: 'docker'
-  image: 'docker://decathlon/release-notes-generator-action:2.0.1'
-branding:
-  icon: tag
-  color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,10 +47,13 @@ else
   mkdir $OUTPUT_FOLDER
 fi
 
+echo "Checking for custom configuration..."
 CONFIG_FILE=".github/release-notes.yml"
 if [[ ! -f ${CONFIG_FILE} ]]; then
     echo "No config file specified."
     CONFIG_FILE=""
+else
+    echo "Configuring the action using $CONFIG_FILE"
 fi
 
 if [[ "$ACTION" == "$TRIGGER_ACTION" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,6 +47,12 @@ else
   mkdir $OUTPUT_FOLDER
 fi
 
+CONFIG_FILE=".github/release-notes.yml"
+if [[ ! -f ${CONFIG_FILE} ]]; then
+    echo "No config file specified."
+    CONFIG_FILE=""
+fi
+
 if [[ "$ACTION" == "$TRIGGER_ACTION" ]]; then
     echo "Creating release notes for Milestone $MILESTONE_NUMBER into the $OUTPUT_FILENAME file"
     java -jar /github-release-notes-generator.jar \
@@ -54,6 +60,7 @@ if [[ "$ACTION" == "$TRIGGER_ACTION" ]]; then
     --releasenotes.github.repository=${REPOSITORY_NAME} \
     --releasenotes.github.username=${GH_USERNAME} \
     --releasenotes.github.password=${GITHUB_TOKEN} \
+    --spring.config.location=${CONFIG_FILE} \
     ${MILESTONE_NUMBER} \
     ${OUTPUT_FOLDER}/${OUTPUT_FILENAME}
     cat ${OUTPUT_FOLDER}/${OUTPUT_FILENAME}


### PR DESCRIPTION
# Configuration

## Why?
The [Spring Lib](https://github.com/spring-io/github-release-notes-generator) used as a base for this action allow the configuration of sections/label using a configuration file.

## What?
With this PR you can add the `.github/release-notes.yml` file in your repository to configure how your labels interact with the lib to create release notes.
Fixed issues #11 
