### PR TITLE
fix: link and configuration update

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,9 +1,7 @@
-releasenotes:
-    sections:
-    - title: "Enhancements"
-        emoji: ":star:"
-        labels: ["new"]
-    - title: "Bugs"
-        emoji: ":beetle:"
-        labels: ["fix"]
+changelog:
+  sections:
+  - title: "Enhancements"
+    labels: ["new"]
+  - title: "Bugs"
+    labels: ["fix"]
   

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 Each time a milestone is closed, this GitHub action scans its attached issues and pull request, and automatically generates a wonderful release note.  
 
-_The action uses [Spring.io release-notes generator](https://github.com/spring-io/github-release-notes-generator) tool._
+_The action uses [Spring.io changelog generator](https://github.com/spring-io/github-changelog-generator) tool._
 
 <p align="center">
   <img src="https://github.com/Decathlon/release-notes-generator-action/raw/master/images/release_notes.png" alt="Result illustration"/>

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: Decathlon <developers@decathlon.com>
 description: This Github action <strong>automatically creates a release notes</strong> when a milestone is closed.
 runs:
   using: 'docker'
-  image: 'docker://decathlon/release-notes-generator-action:2.1.0'
+  image: 'docker://decathlon/release-notes-generator-action:3.0.0'
 branding:
   icon: tag
   color: blue


### PR DESCRIPTION
## Why?

After the update of the library to the 0.0.5 some link in the readme was not correct anymore. Even the configuration to use the custom tags has changed.

## What?
Aligned the documentation to the new plugin version