### PR TITLE
fix: use temporary version of changelog app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV RELEASE_NOTE_GENERATOR_VERSION="v0.0.5"
 
 COPY *.sh /
 RUN chmod +x JSON.sh && \
-    wget -O github-release-notes-generator.jar https://github.com/spring-io/github-changelog-generator/releases/download/${RELEASE_NOTE_GENERATOR_VERSION}/github-changelog-generator.jar
+    #wget -O github-release-notes-generator.jar https://github.com/spring-io/github-changelog-generator/releases/download/${RELEASE_NOTE_GENERATOR_VERSION}/github-changelog-generator.jar
+    wget -O github-release-notes-generator.jar https://ucd1f7512113b0c593d98dba7d90.dl.dropboxusercontent.com/cd/0/get/BFU15LNNmRHvWpIeQ31s3JxWsc1L2JnBNmTEcj_6zJbELHm4QcZLQe8dQC5CXtesNJPdUIYT-hu7E6kmEX40As8Sogi4_XkTX3-mnFecFusHfSTLQhbKD9eZPp-NbOldrzw/file?dl=1#
 
 COPY entrypoint.sh /
 


### PR DESCRIPTION
## Why?
After the update to the 0.0.5 version of the [github-changelog-generator](https://github.com/spring-io/github-changelog-generator) the action is working only with standard configuration. It is not possible to upgrade the configuration anymore using the custom configuration file from the `.github` folder.
After all the tests made with @lfgcampos we found the problem is related to the fact configuration file in hidden folders (starting with `.`) are not taken in count anymore by the `--spring.config.location` option.
This is due to an [issue](https://github.com/spring-projects/spring-boot/issues/23983) into the Spring Boot 2.3.5 (fixed in 2.3.6).

## What?
This PR is fixing the problem discussed in Issue #15 
Thanks to @lfgcampos for all the tests and contributions!!

We are using a temporary JAR built against the master branch of the [github-changelog-generator](https://github.com/spring-io/github-changelog-generator).
We will switch back to the standard configuration once the project will release the 0.0.6 version with Spring Boot 2.4.1.