### PR TITLE
feat: added support for workflow dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ jobs:
         USE_MILESTONE_TITLE: "true"
 ```
 
+#### Settings for workflow_dispatch
+Since the release 3.1.0 the action supports to trigger it via the (GitHub workflow_dispatch)[https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/] allowing to manually trigger an action workflow.
+To use it you should add a dispatch configuration in your action, like the following.
+```yaml
+on:
+  milestone:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      milestoneId:
+        description: 'Milestone ID'     
+        required: true
+        default: '1'
+```
+It is important to keep the `milestoneId` variable name which is used inside the Action itself.
+With the configuration in the example the action is triggered both for milestone closure and workflow_dispatch.
+
 #### NOTE
 It is important to add the *GITHUB_TOKEN* secret because the action needs to access to your repository Milestone/Issues information using the GitHub API.
 


### PR DESCRIPTION
## Why?
GitHub added a while ago a way to manually trigger actions workflow: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
In some cases it would be useful to be able to trigger the action without opening/closing the milestone (for example in case of errors).

## What?
Action is updated to be able to take in count the milestone ID from the workflow_dispatch parameters instead of the GitHub event json object.

Closes Issue #14 

## Tests
All the tests were made [here](https://github.com/mmornati/test-relese-notes/runs/1581688907?check_suite_focus=true).
The PR is working both for the workflow_dispatch workflow and the milestone closure one.
![image](https://user-images.githubusercontent.com/139323/102691698-a202cd00-420e-11eb-80ec-06ba65e89cae.png)
![image](https://user-images.githubusercontent.com/139323/102691711-b3e47000-420e-11eb-80a0-e16df03e6f9f.png)
 