### PR TITLE
fix: temporary jar link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV RELEASE_NOTE_GENERATOR_VERSION="v0.0.5"
 COPY *.sh /
 RUN chmod +x JSON.sh && \
     #wget -O github-release-notes-generator.jar https://github.com/spring-io/github-changelog-generator/releases/download/${RELEASE_NOTE_GENERATOR_VERSION}/github-changelog-generator.jar
-    wget -O github-release-notes-generator.jar https://ucd1f7512113b0c593d98dba7d90.dl.dropboxusercontent.com/cd/0/get/BFU15LNNmRHvWpIeQ31s3JxWsc1L2JnBNmTEcj_6zJbELHm4QcZLQe8dQC5CXtesNJPdUIYT-hu7E6kmEX40As8Sogi4_XkTX3-mnFecFusHfSTLQhbKD9eZPp-NbOldrzw/file?dl=1#
+    wget -O github-release-notes-generator.jar https://www.dropbox.com/s/uwqa2bgkp0qsyna/github-changelog-generator.jar?dl=1 
 
 COPY entrypoint.sh /
 


### PR DESCRIPTION
## Why?
The temporary link from Dropbox seems broken and build is not working anymore.

## What?
But the correct link in the dockerfile
This is fixing a problem in the same way described in the PR #21 