### PR TITLE
fix: problem in variables name

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,8 +63,8 @@ if [[ "workflow_dispatch" == "$GITHUB_EVENT_NAME" || "$ACTION" == "$TRIGGER_ACTI
     echo "Creating release notes for Milestone $MILESTONE_NUMBER into the $OUTPUT_FILENAME file"
     java -jar /github-release-notes-generator.jar \
     --changelog.repository=${OWNER_ID}/${REPOSITORY_NAME} \
-    --changelog.github.username=${GH_USERNAME} \
-    --changelog.github.password=${GITHUB_TOKEN} \
+    --github.username=${GH_USERNAME} \
+    --github.password=${GITHUB_TOKEN} \
     --changelog.milestone-reference=id \
     --spring.config.location=${CONFIG_FILE} \
     ${MILESTONE_ID_TO_USE} \


### PR DESCRIPTION
## Why?
In latest refactor of the libraries, variables to provide information change for `changelog`, and in the refactor the username/password, used for private repositories only, are not having the correct and expected name.
The information from the [official repository](https://github.com/spring-io/github-changelog-generator) are:
```
changelog:
  repository: owner/name
github:
  username:
  password:
```
This means the CLI variables should be `--github.username` and `--github.password`

## What?
Refactoring putting the correct name for username and password parameters used to access to the GitHub APIs.
Closes #26 