### PR TITLE
Upgrade spring github-changelog-generato to v0.0.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ LABEL "com.github.actions.description"="Create a release notes of milestone"
 LABEL "com.github.actions.icon"="pocket"
 LABEL "com.github.actions.color"="blue"
 
-ENV RELEASE_NOTE_GENERATOR_VERSION="v0.0.8"
+ENV RELEASE_NOTE_GENERATOR_VERSION="v0.0.12"
 
 COPY *.sh /
 RUN chmod +x JSON.sh && \
     wget -O github-release-notes-generator.jar https://github.com/spring-io/github-changelog-generator/releases/download/${RELEASE_NOTE_GENERATOR_VERSION}/github-changelog-generator.jar
-    
+
 COPY entrypoint.sh /
 
 ENTRYPOINT ["sh", "/entrypoint.sh"]


### PR DESCRIPTION
If the milestone has more than one page, the "github-changelog-generator" will return a 422 and the generation does not work. This was fixed in v0.0.12

see https://github.com/spring-io/github-changelog-generator/releases/tag/v0.0.12

@mmornati can you please have a look and release a new version?