### PR TITLE
Fix Docker image - Replace deprecated openjdk:8-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM eclipse-temurin:11-alpine
 LABEL "maintainer"="Decathlon <developers@decathlon.com>"
 LABEL "com.github.actions.name"="release-notes-generator-action"
 LABEL "com.github.actions.description"="Create a release notes of milestone"


### PR DESCRIPTION
The `openjdk:8-alpine` image has been deprecated and removed from Docker Hub, causing the action to fail with "not found" errors.

This PR updates the Dockerfile to use `eclipse-temurin:11-alpine` as a replacement.
   
Tested and confirmed working.